### PR TITLE
Adding inclusion of the 'isParallel'

### DIFF
--- a/src/hir/symbols.rs
+++ b/src/hir/symbols.rs
@@ -483,7 +483,9 @@ impl SymbolKind {
             UsageKind::Allocation => Self::AllocationUsage,
             UsageKind::Requirement | UsageKind::SatisfyRequirement => Self::RequirementUsage,
             UsageKind::Constraint => Self::ConstraintUsage,
-            UsageKind::State | UsageKind::ExhibitState | UsageKind::Transition => Self::StateUsage,
+            UsageKind::State { is_parallel: _ }
+            | UsageKind::ExhibitState { is_parallel: _ }
+            | UsageKind::Transition => Self::StateUsage,
             UsageKind::Calculation => Self::CalculationUsage,
             UsageKind::Reference => Self::ReferenceUsage,
             UsageKind::Occurrence

--- a/src/syntax/normalized.rs
+++ b/src/syntax/normalized.rs
@@ -524,9 +524,9 @@ impl<'a> NormalizedUsage<'a> {
                 NormalizedUsageKind::Requirement
             }
             UsageKind::Constraint => NormalizedUsageKind::Constraint,
-            UsageKind::State | UsageKind::ExhibitState | UsageKind::Transition => {
-                NormalizedUsageKind::State
-            }
+            UsageKind::State { is_parallel: _ }
+            | UsageKind::ExhibitState { is_parallel: _ }
+            | UsageKind::Transition => NormalizedUsageKind::State,
             UsageKind::Calculation => NormalizedUsageKind::Calculation,
             UsageKind::Reference => NormalizedUsageKind::Reference,
             UsageKind::Occurrence

--- a/src/syntax/sysml/ast/enums.rs
+++ b/src/syntax/sysml/ast/enums.rs
@@ -63,14 +63,18 @@ pub enum UsageKind {
     // Domain-specific usage types
     SatisfyRequirement,
     PerformAction,
-    ExhibitState,
+    ExhibitState {
+        is_parallel: bool,
+    },
     IncludeUseCase,
     // Reference usages (parameters with direction like `in`, `out`, `inout`)
     Reference,
     // Additional usage types
     Constraint,
     Calculation,
-    State,
+    State {
+        is_parallel: bool,
+    },
     Connection,
     Interface,
     Allocation,

--- a/src/syntax/sysml/ast/parsers.rs
+++ b/src/syntax/sysml/ast/parsers.rs
@@ -1381,7 +1381,7 @@ fn visit_body_member_single<'a>(
         _ if is_usage_rule(rule) => {
             let usage = parse_usage_with_kind(
                 pair.clone(),
-                to_usage_kind(rule).unwrap_or(UsageKind::Reference),
+                to_usage_kind(pair).unwrap_or(UsageKind::Reference),
             );
             ctx.def_members
                 .push(DefinitionMember::Usage(Box::new(usage.clone())));
@@ -1652,7 +1652,7 @@ fn parse_usage_with_kind(pair: Pair<Rule>, kind: UsageKind) -> Usage {
 
 /// Parse a usage, inferring kind from the rule
 pub fn parse_usage(pair: Pair<Rule>) -> Usage {
-    let kind = to_usage_kind(pair.as_rule()).unwrap_or(UsageKind::Reference);
+    let kind = to_usage_kind(&pair).unwrap_or(UsageKind::Reference);
     parse_usage_with_kind(pair, kind)
 }
 

--- a/src/syntax/sysml/ast/tests/tests_types_usage.rs
+++ b/src/syntax/sysml/ast/tests/tests_types_usage.rs
@@ -402,14 +402,16 @@ fn test_usage_kind_perform_action() {
 
 #[test]
 fn test_usage_kind_exhibit_state() {
-    let usage = Usage::new(
-        UsageKind::ExhibitState,
-        Some("exhibit".to_string()),
-        Relationships::none(),
-        vec![],
-    );
+    for is_parallel in [true, false] {
+        let usage = Usage::new(
+            UsageKind::ExhibitState { is_parallel },
+            Some("exhibit".to_string()),
+            Relationships::none(),
+            vec![],
+        );
 
-    assert_eq!(usage.kind, UsageKind::ExhibitState);
+        assert_eq!(usage.kind, UsageKind::ExhibitState { is_parallel });
+    }
 }
 
 #[test]

--- a/src/syntax/sysml/ast/types.rs
+++ b/src/syntax/sysml/ast/types.rs
@@ -713,7 +713,7 @@ impl Usage {
         match self.kind {
             UsageKind::SatisfyRequirement
             | UsageKind::PerformAction
-            | UsageKind::ExhibitState
+            | UsageKind::ExhibitState { is_parallel: _ }
             | UsageKind::IncludeUseCase => {
                 if let Some(ref typed_by) = self.relationships.typed_by {
                     Some((typed_by.as_str(), self.relationships.typed_by_span))

--- a/tests/syntax/tests_sysml_ast.rs
+++ b/tests/syntax/tests_sysml_ast.rs
@@ -5,11 +5,13 @@
 //! structure of the resulting AST.
 
 #![allow(clippy::unwrap_used)]
+use rstest::rstest;
 
 use std::path::PathBuf;
 use syster::project::file_loader;
 use syster::syntax::sysml::ast::Element;
 use syster::syntax::sysml::ast::enums::DefinitionKind;
+use syster::syntax::sysml::ast::enums::UsageKind;
 
 #[test]
 fn test_parse_attribute_def_from_stdlib() {
@@ -111,4 +113,60 @@ fn test_parse_abstract_attribute_def() {
         def.is_abstract,
         "Should be marked as abstract - THIS IS THE BUG!"
     );
+}
+
+#[rstest]
+#[case("", "")]
+#[case("", "parallel")]
+#[case("exhibit", "")]
+#[case("exhibit", "parallel")]
+fn test_parsing_state_usage_parallel_attribute(
+    #[case] exhibit_prefix: &str,
+    #[case] parallel_modifier: &str,
+) {
+    let is_parallel_expected = parallel_modifier == "parallel";
+    let is_exhibit_usage_expected = exhibit_prefix == "exhibit";
+
+    let input = exhibit_prefix.to_owned()
+        + r#" state parallelStates "#
+        + parallel_modifier
+        + r#" {
+                state operatingStates {
+                    state on;
+                    state off;
+                }
+                state monitoringStates {
+                    state healthy;
+                    state unhealthy;
+                }
+            }
+    "#;
+
+    let path = PathBuf::from("test.sysml");
+    let parse_result = file_loader::parse_with_result(&input, &path);
+    let language_file = parse_result.content.expect("Parse should succeed");
+
+    let file = match language_file {
+        syster::syntax::SyntaxFile::SysML(f) => f,
+        _ => panic!("Expected SysML file"),
+    };
+
+    assert_eq!(file.elements.len(), 1);
+
+    let usage = match &file.elements[0] {
+        Element::Usage(usage) => usage,
+        _ => panic!("Expected Usage"),
+    };
+
+    match usage.kind {
+        UsageKind::ExhibitState { is_parallel } => {
+            assert!(is_exhibit_usage_expected);
+            assert_eq!(is_parallel, is_parallel_expected);
+        }
+        UsageKind::State { is_parallel } => {
+            assert!(!is_exhibit_usage_expected);
+            assert_eq!(is_parallel, is_parallel_expected);
+        }
+        _ => panic!("Expected ExhibitState"),
+    }
 }


### PR DESCRIPTION
  - Currently the 'AST' doesn't include some type specific attributes. 
  - Adding a possible mechanism to set specific attributes.