### PR TITLE
Three parser bugs fixed

### DIFF
--- a/src/hir/symbols/types.rs
+++ b/src/hir/symbols/types.rs
@@ -719,6 +719,7 @@ impl SymbolKind {
             Some(DefinitionKind::Flow) => Self::Other,
             Some(DefinitionKind::Metadata) => Self::Other,
             Some(DefinitionKind::Occurrence) => Self::OccurrenceDefinition,
+            Some(DefinitionKind::Actor) => Self::Other,
             // KerML mappings
             Some(DefinitionKind::Class) => Self::PartDefinition,
             Some(DefinitionKind::Struct) => Self::PartDefinition,

--- a/src/parser/ast/elements.rs
+++ b/src/parser/ast/elements.rs
@@ -148,6 +148,7 @@ impl Definition {
         VERIFICATION_KW => Verification,
         USE_KW => UseCase,
         CONCERN_KW => Concern,
+        ACTOR_KW => Actor,
         // KerML definition keywords
         CLASS_KW => Class,
         STRUCT_KW => Struct,
@@ -197,6 +198,7 @@ pub enum DefinitionKind {
     Verification,
     UseCase,
     Concern,
+    Actor,
     // KerML kinds
     Class,
     Struct,

--- a/src/parser/grammar/sysml/entry.rs
+++ b/src/parser/grammar/sysml/entry.rs
@@ -300,14 +300,20 @@ pub fn parse_package_body_element<P: SysMLParser>(p: &mut P) {
             }
         }
         SyntaxKind::ACTOR_KW => {
-            let (_, next) = peek_past_optional_name(p, 1);
-            if next == SyntaxKind::EQ
-                || next == SyntaxKind::COLON_GT_GT
-                || next == SyntaxKind::COLON_GT
-            {
-                p.parse_shorthand_feature_member();
+            let lookahead = skip_trivia_lookahead(p, 1);
+            if p.peek_kind(lookahead) == SyntaxKind::DEF_KW {
+                // actor def Name { ... }
+                p.parse_definition_or_usage();
             } else {
-                parse_actor_usage(p);
+                let (_, next) = peek_past_optional_name(p, 1);
+                if next == SyntaxKind::EQ
+                    || next == SyntaxKind::COLON_GT_GT
+                    || next == SyntaxKind::COLON_GT
+                {
+                    p.parse_shorthand_feature_member();
+                } else {
+                    parse_actor_usage(p);
+                }
             }
         }
         SyntaxKind::STAKEHOLDER_KW => {
@@ -428,13 +434,38 @@ pub fn parse_package_body_element<P: SysMLParser>(p: &mut P) {
     }
 }
 
-/// Parse prefix metadata (#name)
-/// Per pest: Prefix metadata appears as #identifier before various declarations
+/// Parse prefix metadata (#name) or prefix metadata with body (#name { ... })
+/// Per pest: Prefix metadata appears as #identifier (with optional body) before various declarations
 pub(super) fn parse_prefix_metadata<P: SysMLParser>(p: &mut P) {
     p.start_node(SyntaxKind::PREFIX_METADATA);
     expect_and_skip(p, SyntaxKind::HASH);
     if p.at_name_token() {
         p.bump();
+        p.skip_trivia();
+    }
+    // Consume optional body { ... } — brace-balanced skip
+    if p.at(SyntaxKind::L_BRACE) {
+        let mut depth = 1usize;
+        p.bump(); // {
+        while depth > 0 {
+            match p.current_kind() {
+                SyntaxKind::L_BRACE => {
+                    depth += 1;
+                    p.bump();
+                }
+                SyntaxKind::R_BRACE => {
+                    depth -= 1;
+                    if depth > 0 {
+                        p.bump();
+                    }
+                }
+                SyntaxKind::ERROR => break,
+                _ => {
+                    p.bump();
+                }
+            }
+        }
+        p.expect(SyntaxKind::R_BRACE);
     }
     p.finish_node();
 }

--- a/src/parser/grammar/sysml/mod.rs
+++ b/src/parser/grammar/sysml/mod.rs
@@ -82,6 +82,7 @@ pub const SYSML_DEFINITION_KEYWORDS: &[SyntaxKind] = &[
     SyntaxKind::CONCERN_KW,
     SyntaxKind::METADATA_KW,
     SyntaxKind::ENUM_KW,
+    SyntaxKind::ACTOR_KW,
 ];
 
 /// SysML usage keywords (used without 'def')

--- a/src/parser/grammar/sysml/usage.rs
+++ b/src/parser/grammar/sysml/usage.rs
@@ -360,7 +360,13 @@ pub fn parse_usage<P: SysMLParser>(p: &mut P) {
 
     // For connection/interface usage: binary endpoint syntax with 'to'
     // Pattern: interface source.port to target.port;
-    if (is_connection_kw || is_interface_kw) && p.at_name_token() && !p.at(SyntaxKind::CONNECT_KW) {
+    // Guard !p.at(TO_KW): 'to' can be used as a feature name (e.g. `attribute to : Type`),
+    // so we must not treat it as the start of a connector endpoint here.
+    if (is_connection_kw || is_interface_kw)
+        && p.at_name_token()
+        && !p.at(SyntaxKind::CONNECT_KW)
+        && !p.at(SyntaxKind::TO_KW)
+    {
         // Check if there's a 'to' keyword ahead
         let has_to = {
             let mut depth = 0;

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -319,6 +319,7 @@ impl<'a> ExpressionParser for Parser<'a> {
                 | SyntaxKind::MEMBER_KW
                 | SyntaxKind::VAR_KW
                 | SyntaxKind::STATE_KW
+                | SyntaxKind::TO_KW
         )
     }
 

--- a/src/syntax/normalized.rs
+++ b/src/syntax/normalized.rs
@@ -794,6 +794,7 @@ impl NormalizedDefinition {
             Some(RowanDefinitionKind::Flow) => NormalizedDefKind::Other, // Map flow def to Other
             Some(RowanDefinitionKind::Metadata) => NormalizedDefKind::Other,
             Some(RowanDefinitionKind::Occurrence) => NormalizedDefKind::Other,
+            Some(RowanDefinitionKind::Actor) => NormalizedDefKind::Other,
             // KerML mappings to SysML equivalents
             Some(RowanDefinitionKind::Class) => NormalizedDefKind::Part, // class -> part def
             Some(RowanDefinitionKind::Struct) => NormalizedDefKind::Part, // struct -> part def

--- a/tests/tests_parser_definitions.rs
+++ b/tests/tests_parser_definitions.rs
@@ -160,3 +160,40 @@ fn test_variation_modifier(#[case] input: &str, #[case] expected_variation: bool
     let def = parse_sysml_def(input).expect("Should parse");
     assert_eq!(def.is_variation(), expected_variation);
 }
+
+/// Reserved keyword 'to' used as attribute name should parse without errors.
+#[test]
+fn test_attribute_named_to() {
+    let parsed = parse_sysml("item def D { attribute to : String[0..1]; }");
+    assert!(parsed.errors.is_empty(), "unexpected errors: {:?}", parsed.errors);
+}
+
+/// 'actor def' should be parsed as a definition, not trigger a usage error.
+#[test]
+fn test_actor_def() {
+    let parsed = parse_sysml("package P { actor def GapFourActor; }");
+    assert!(parsed.errors.is_empty(), "unexpected errors: {:?}", parsed.errors);
+    let file = syster::parser::SourceFile::cast(parsed.syntax()).expect("cast");
+    let pkg = file.members().find_map(|m| match m {
+        syster::parser::NamespaceMember::Package(p) => Some(p),
+        _ => None,
+    }).expect("package");
+    let def = pkg.body().expect("body").members().find_map(|m| match m {
+        syster::parser::NamespaceMember::Definition(d) => Some(d),
+        _ => None,
+    }).expect("definition");
+    assert_eq!(def.definition_kind(), Some(DefinitionKind::Actor));
+    assert_eq!(def.name().and_then(|n| n.text()), Some("GapFourActor".to_string()));
+}
+
+/// Prefix metadata with a body block (#Tag { ... }) should not swallow the following member.
+#[test]
+fn test_prefix_metadata_with_body() {
+    let parsed = parse_sysml(
+        r#"package P {
+            #AnyTag { :>> ref = "spec.adoc"; }
+            use case def <'UC-LOST'> LostCase { action step_a; }
+        }"#,
+    );
+    assert!(parsed.errors.is_empty(), "unexpected errors: {:?}", parsed.errors);
+}


### PR DESCRIPTION
1. `attribute to : String[0..1]` `TO_KW` was not in `at_name_token()`, so `to` could not be parsed as a feature name.

- `parser.rs`: Added `SyntaxKind::TO_KW` to the contextual-keyword name list.
- `usage.rs`: Added `&& !p.at(SyntaxKind::TO_KW)` guard on the binary-endpoint connector check so that `to` at the start of that check position isn't mistakenly consumed as a connector source endpoint.

2. `actor def GapFourActor` `ACTOR_KW` was only handled as a usage keyword, causing "expected ';', found 'def'" when followed by `def`.
- `mod.rs`: Added `ACTOR_KW` to `SYSML_DEFINITION_KEYWORDS`.
- `entry.rs`: In the `ACTOR_KW` match arm, added a lookahead for `DEF_KW`; if found, dispatches to `parse_definition_or_usage()`.
- `elements.rs`: Added `Actor` to `DefinitionKind` and its token mapping.
- `types.rs` / `normalized.rs`: Added `Actor => Other` to the two exhaustive matches.

3. `#AnyTag { :>> ref = "some-spec.adoc"; }` before a member — `parse_prefix_metadata` only consumed `#name` without the body, leaving `{` as the next token, which caused error recovery to close the enclosing package body early and detach the following `use case def`.
- `entry.rs`: Extended `parse_prefix_metadata` to brace-balance-skip an optional `{ ... }` body after the name.